### PR TITLE
Init IRQ conditionally

### DIFF
--- a/lab004/firmware/isr.c
+++ b/lab004/firmware/isr.c
@@ -1,17 +1,26 @@
 #include <generated/csr.h>
+#include <generated/soc.h>
 #include <irq.h>
 #include <uart.h>
 
-extern void periodic_isr(void);
-
 void isr(void);
+
+#ifdef CONFIG_CPU_HAS_INTERRUPT
+
 void isr(void)
 {
-	unsigned int irqs;
+	__attribute__((unused)) unsigned int irqs;
 
 	irqs = irq_pending() & irq_getmask();
 
+#ifndef UART_POLLING
 	if(irqs & (1 << UART_INTERRUPT))
 		uart_isr();
-
+#endif
 }
+
+#else
+
+void isr(void){};
+
+#endif

--- a/lab004/firmware/main.c
+++ b/lab004/firmware/main.c
@@ -122,8 +122,10 @@ static void console_service(void)
 
 int main(void)
 {
+#ifdef CONFIG_CPU_HAS_INTERRUPT
 	irq_setmask(0);
 	irq_setie(1);
+#endif
 	uart_init();
 
 	puts("\nLab004 - CPU testing software built "__DATE__" "__TIME__"\n");


### PR DESCRIPTION
This enables drop-in replacement of the CPU with cores that don't have interrupts like SERV.

The lab004 firmware is an excellent base to create a firmware so I will link it in the [Bare Metal](https://github.com/timvideos/litex-buildenv/wiki/Bare-Metal) wiki page.