### PR TITLE
Fixed broken Makefile

### DIFF
--- a/lab004/firmware/Makefile
+++ b/lab004/firmware/Makefile
@@ -15,14 +15,15 @@ all: firmware.bin
 	chmod -x $@
 
 firmware.elf: $(OBJECTS)
-	$(LD) $(LDFLAGS) \
+	$(CC) $(LDFLAGS) \
 		-T linker.ld \
 		-N -o $@ \
-		 $(BUILD_DIR)/software/libbase/crt0.o \
+		 $(BUILD_DIR)/software/bios/crt0.o \
 		$(OBJECTS) \
 		-L$(BUILD_DIR)/software/libbase \
 		-L$(BUILD_DIR)/software/libcompiler_rt \
-		-lbase-nofloat -lcompiler_rt
+		-L$(BUILD_DIR)/software/libc \
+		-lbase -lcompiler_rt -lc
 	chmod -x $@
 
 main.o: main.c


### PR DESCRIPTION
fixes enjoy-digital/litex#1202

Hello,

me, @alexandrekj and @MCassidy2411 were having the same problem of the issue. We solved by changing a few things in the firmware/Makefile file.

Begining in line 17:

- we changed LD to CC
- the crt0.o is in the bios directory
- The Libc is also needed by the c-code
- The Libbase changed its name from -lbase-nofloat to -lbase
