### PR TITLE
lab004/firmware: fix firmware build

### DIFF
--- a/lab004/firmware/Makefile
+++ b/lab004/firmware/Makefile
@@ -3,7 +3,7 @@ BUILD_DIR=../build/
 include $(BUILD_DIR)/software/include/generated/variables.mak
 include $(SOC_DIRECTORY)/software/common.mak
 
-OBJECTS=isr.o main.o
+OBJECTS=isr.o main.o crt0.o
 
 all: firmware.bin
 

--- a/lab004/firmware/linker.ld
+++ b/lab004/firmware/linker.ld
@@ -10,6 +10,12 @@ SECTIONS
 	.text :
 	{
 		_ftext = .;
+		/* Make sure crt0 files come first, and they, and the isr */
+		/* don't get disposed of by greedy optimisation */
+		*crt0*(.text)
+		KEEP(*crt0*(.text))
+		KEEP(*(.text.isr))
+
 		*(.text .stub .text.* .gnu.linkonce.t.*)
 		_etext = .;
 	} > main_ram


### PR DESCRIPTION
Fixes two separate issues that were keeping lab004 from working.

The first is a minor but important oversight from https://github.com/litex-hub/fpga_101/commit/b36c77a8f004cbdc130e7a492d79499a5025917c: It added a definition for crt0.o but then didn't refer to it anywhere, effectively removing crt0.o from the build.

That was likely the cause of https://github.com/litex-hub/fpga_101/issues/12.

The second issue I don't understand as well, but seems to be exactly the same as https://github.com/enjoy-digital/litex/pull/1007, from which I copied the fix.

Before these fixes, lab004 was failing for me in the same way as described in #12 (and #11). After these fixes, it is working.

Resolves #12 